### PR TITLE
fixes to work with fastboot 28.0.2-debian ("invalid fastboot option -i" error)

### DIFF
--- a/chip-fel-flash.sh
+++ b/chip-fel-flash.sh
@@ -197,10 +197,10 @@ else
 
 	echo == waiting for fastboot ==
 	if wait_for_fastboot; then
-		fastboot -i 0x1f3a -u flash UBI ${SPARSE_UBI}
+		fastboot --unbuffered flash UBI ${SPARSE_UBI}
 		assert_error 134
 
-		fastboot -i 0x1f3a continue
+		fastboot continue
 		assert_error 135
 	else
 		rm -rf "${TMPDIR}"

--- a/chip-flash
+++ b/chip-flash
@@ -266,10 +266,10 @@ else
 
         log "== waiting for fastboot =="
         if wait_for_fastboot ${FASTBOOT_PORT}; then
-            fastboot ${FASTBOOT_PORT} -i 0x1f3a -u flash UBI ${SPARSE_UBI} > /dev/null
+            fastboot ${FASTBOOT_PORT} --unbuffered flash UBI ${SPARSE_UBI} > /dev/null
             assert_error 134
 
-            fastboot ${FASTBOOT_PORT} -i 0x1f3a continue > /dev/null
+            fastboot ${FASTBOOT_PORT} continue > /dev/null
             assert_error 135
         else
             exit 1

--- a/common.sh
+++ b/common.sh
@@ -52,7 +52,7 @@ wait_for_fastboot() {
   echo -n "waiting for fastboot...";
   export FLASH_WAITING_FOR_DEVICE=1
   for ((i=$TIMEOUT; i>0; i--)) {
-    if [[ ! -z "$(${FASTBOOT} -i 0x1f3a $@ devices)" ]]; then
+    if [[ ! -z "$(${FASTBOOT} $@ devices)" ]]; then
       echo "OK";
       unset FLASH_WAITING_FOR_DEVICE
       return 0;
@@ -227,8 +227,8 @@ flash_images() {
 
   export FLASH_VID_PID=1f3a1010
   if wait_for_fastboot; then
-    ${FASTBOOT} -i 0x1f3a -u flash UBI $IMAGESDIR/chip-$nand_erasesize-$nand_writesize-$nand_oobsize.ubi.sparse || RC=1
-    ${FASTBOOT} -i 0x1f3a continue > /dev/null
+    ${FASTBOOT} --unbuffered flash UBI $IMAGESDIR/chip-$nand_erasesize-$nand_writesize-$nand_oobsize.ubi.sparse || RC=1
+    ${FASTBOOT} continue > /dev/null
   else
     echo "failed to flash the UBI image"
     RC=1


### PR DESCRIPTION
Realized I have a pocketchip laying around that I needed to reset because I forgot the password, and discovered there are a few things out of date with the fastboot options, hopefully this helps someone else. For me this worked from a Raspberry Pi 4 over USB with FEL/GRN set.